### PR TITLE
  Fix No space left on device error.

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,7 +72,9 @@ binary
 
 `No space left on device`
 
-Export CUSTOM_IMG_SIZE={Size in MiB of output image file} larger, default 4096 (4GiB)
+Export CUSTOM_IMG_SIZE={Size in MiB of output image file} larger, default 4096 (4GiB).
+
+If the above does not fix the issue (Check the sizeof(boot.tar + custom-root.tar) < CUSTOM_IMG_SIZE), Docker may be out of allocated space. The command `docker system prune` can be used to clean up old docker image data (use with care - removed contents are not recoverable).
 
 ## Author
 

--- a/support/3-compose.sh
+++ b/support/3-compose.sh
@@ -49,6 +49,9 @@ echo "Creating custom image"
 dd if=/dev/zero of=./${CUSTOM_IMG_NAME} bs=1M count=${CUSTOM_IMG_SIZE}
 # Copying partition table from base Raspbian image (saved in 'extract')
 sfdisk ${CUSTOM_IMG_NAME} < "${PT_FILENAME}"
+# Increase the linux partition size to the remaining space within CUSTOM_IMG_SIZE
+echo ", +" | sfdisk custom.img -N 2
+
 # Create loopback device
 sudo losetup -fP ${CUSTOM_IMG_NAME}
 LODEV=$(losetup -a | grep "${CUSTOM_IMG_NAME}" | awk -F: '{ print $1 }')


### PR DESCRIPTION
Fixing issue whereby the custom image cannot be untarred onto the custom disk if it is larger than the source image. Added sfdisk step to expand new image partition to use all available space.